### PR TITLE
PDF from URL with download progress status (with updated example)

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,9 +61,9 @@ class _MyAppStateWithProgress extends State<MyApp> {
     }
 
     String progressString =
-        '${parseBytesToKBs(downloadProgress.downloaded)} KBs';
+        parseBytesToKBs(downloadProgress.downloaded);
     if (downloadProgress.totalSize != null) {
-      progressString += '/ ${parseBytesToKBs(downloadProgress.totalSize)} KBs';
+      progressString += '/ ${parseBytesToKBs(downloadProgress.totalSize)}';
     }
 
     return Column(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,11 +1,101 @@
 import 'package:flutter/material.dart';
 import 'package:easy_pdf_viewer/easy_pdf_viewer.dart';
 
-void main() => runApp(MyApp());
+void main() => runApp(MyApp(
+      progressExample: true,
+    ));
 
 class MyApp extends StatefulWidget {
+  const MyApp({this.progressExample = false});
+
+  final bool progressExample;
+
   @override
-  _MyAppState createState() => _MyAppState();
+  State<MyApp> createState() {
+    if (progressExample) return _MyAppStateWithProgress();
+    return _MyAppState();
+  }
+}
+
+class _MyAppStateWithProgress extends State<MyApp> {
+  bool _isLoading = true;
+  PDFDocument document;
+  DownloadProgress downloadProgress;
+
+  @override
+  void initState() {
+    loadDocument();
+    super.initState();
+  }
+
+  @override
+  void setState(VoidCallback fn) {
+    if (mounted) {
+      super.setState(fn);
+    }
+  }
+
+  void loadDocument() async {
+
+    /// Clears the cache before download, so [PDFDocument.fromURLWithDownloadProgress.downloadProgress()]
+    /// is always executed (meant only for testing).
+    await DefaultCacheManager().emptyCache();
+
+    PDFDocument.fromURLWithDownloadProgress(
+      'https://www.ecma-international.org/wp-content/uploads/ECMA-262_12th_edition_june_2021.pdf',
+      downloadProgress: (downloadProgress) => setState(() {
+        this.downloadProgress = downloadProgress;
+      }),
+      onDownloadComplete: (document) => setState(() {
+        this.document = document;
+        _isLoading = false;
+      }),
+    );
+  }
+
+  Widget buildProgress() {
+    if (downloadProgress == null) return SizedBox();
+
+    String parseBytesToKBs(int bytes) {
+      return '${(bytes / 1000).toStringAsFixed(2)} KBs';
+    }
+
+    String progressString =
+        '${parseBytesToKBs(downloadProgress.downloaded)} KBs';
+    if (downloadProgress.totalSize != null) {
+      progressString += '/ ${parseBytesToKBs(downloadProgress.totalSize)} KBs';
+    }
+
+    return Column(
+      children: [
+        SizedBox(height: 20),
+        Text(progressString),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SafeArea(
+          child: _isLoading
+              ? Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      CircularProgressIndicator(),
+                      buildProgress(),
+                    ],
+                  ),
+                )
+              : PDFViewer(
+                  document: document,
+                ),
+        ),
+      ),
+    );
+  }
 }
 
 class _MyAppState extends State<MyApp> {


### PR DESCRIPTION
**TLDR**
New method to load pdf from url with current download status

**Why?**
If the PDF file is large, or the internet is slow, it would be good for the user to know the how much(or how fast) the file is downloading.

**What**
New function in PDFDocument with callbacks for download progress status. Also updated the example's main.dart to demonstrate this feature.

**How**
Using FlutterCacheManger, invoking getFileStream() instead of the getSingleFile() method to download the file. We then make use of the Stream\<FileResponse\> to invoke the downloadProgress (continuously while downloading) and onDownloadComplete(once download is finished) callbacks in our created function.

Using this introduced method we can get the download information, which can be used like so:

<img width="445" alt="Screenshot 2022-08-27 at 5 52 18 AM" src="https://user-images.githubusercontent.com/22625661/187006696-4ede503a-54a6-4926-8137-42063d8dfb87.png">