### PR TITLE
AAPT: error: resource android:attr/lStar not found. error solved.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,9 +23,10 @@ apply plugin: 'com.android.library'
 
 android {
     namespace "dev.kaichi.easy_pdf_viewer"
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16
     }
 }
+


### PR DESCRIPTION
#34 This issue was resolved by increasing compileSdkVersion from 30 to 31.